### PR TITLE
feat : Octree + Frustum Culling

### DIFF
--- a/W03StaticMesh_1/Week0v2/Engine/Source/Runtime/CoreUObject/UObject/UObjectArray.cpp
+++ b/W03StaticMesh_1/Week0v2/Engine/Source/Runtime/CoreUObject/UObject/UObjectArray.cpp
@@ -5,13 +5,13 @@
 
 void FUObjectArray::AddObject(UObject* Object)
 {
-    ObjObjects.Add(Object);
+    ObjObjects.Add(Object->GetUUID(), Object);
     AddToClassMap(Object);
 }
 
 void FUObjectArray::MarkRemoveObject(UObject* Object)
 {
-    ObjObjects.Remove(Object);
+    ObjObjects.Remove(Object->GetUUID());
     RemoveFromClassMap(Object);  // UObjectHashTable에서 Object를 제외
     PendingDestroyObjects.AddUnique(Object);
 }

--- a/W03StaticMesh_1/Week0v2/Engine/Source/Runtime/CoreUObject/UObject/UObjectArray.h
+++ b/W03StaticMesh_1/Week0v2/Engine/Source/Runtime/CoreUObject/UObject/UObjectArray.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 #include "Container/Array.h"
+#include "Container/Map.h"
 #include "Container/Set.h"
 
 class UClass;
@@ -14,18 +15,18 @@ public:
 
     void ProcessPendingDestroyObjects();
 
-    TSet<UObject*>& GetObjectItemArrayUnsafe()
+     TMap<uint32, UObject*>& GetObjectItemArrayUnsafe()
     {
         return ObjObjects;
     }
 
-    const TSet<UObject*>& GetObjectItemArrayUnsafe() const
+    const  TMap<uint32, UObject*>& GetObjectItemArrayUnsafe() const
     {
         return ObjObjects;
     }
 
 private:
-    TSet<UObject*> ObjObjects;
+    TMap<uint32, UObject*> ObjObjects;
     TArray<UObject*> PendingDestroyObjects;
 };
 

--- a/W03StaticMesh_1/Week0v2/Engine/Source/Runtime/Launch/EngineLoop.cpp
+++ b/W03StaticMesh_1/Week0v2/Engine/Source/Runtime/Launch/EngineLoop.cpp
@@ -149,14 +149,14 @@ void FEngineLoop::Render()
         for (int i = 0; i < 4; ++i)
         {
             LevelEditor->SetViewportClient(i);
-            renderer.PrepareRender();
+            renderer.PrepareRender(viewportClient);
             renderer.Render(GetWorld(),LevelEditor->GetActiveViewportClient());
         }
         GetLevelEditor()->SetViewportClient(viewportClient);
     }
     else
     {
-        renderer.PrepareRender();
+        renderer.PrepareRender(LevelEditor->GetActiveViewportClient());
         renderer.Render(GetWorld(),LevelEditor->GetActiveViewportClient());
     }
 }

--- a/W03StaticMesh_1/Week0v2/Engine/Source/Runtime/Renderer/Renderer.h
+++ b/W03StaticMesh_1/Week0v2/Engine/Source/Runtime/Renderer/Renderer.h
@@ -136,7 +136,7 @@ public: // line shader
     void UpdateConesBuffer(ID3D11Buffer* pConeBuffer, const TArray<FCone>& Cones, int numCones) const;
 
     //Render Pass Demo
-    void PrepareRender();
+    void PrepareRender(std::shared_ptr<FEditorViewportClient> ActiveViewport);
     void ClearRenderArr();
     void Render(UWorld* World, std::shared_ptr<FEditorViewportClient> ActiveViewport);
     void RenderStaticMeshes(UWorld* World, std::shared_ptr<FEditorViewportClient> ActiveViewport);


### PR DESCRIPTION
FRenderer::PrepareRender(std::shared_ptr<FEditorViewportClient> ActiveViewport)에서 const FFrustum Frustum(ActiveViewport->GetViewMatrix(), ActiveViewport->GetProjectionMatrix());
    
    // 전역적으로 관리되는 UObject 배열에서 TMap으로 변경된 매핑을 가져옵니다.
    TMap<uint32, UObject*> ObjectMap = GUObjectArray.GetObjectItemArrayUnsafe();
    
    // Octree의 FrustumCull을 호출하여, 프러스텀 내에 있는 요소들에 대해 처리합니다.
    const auto ocTree =  GEngineLoop.GetWorld()->GetOcTree();;
    ocTree.FrustumCull(Frustum, [&](const FOctreeElement& element)
    {
        // TMap에서 element.Id를 키로 UObject*를 조회합니다.
        UObject** FoundObj = ObjectMap.Find(element.Id);
        if (FoundObj)
        {
             // UObject*를 UStaticMeshComponent*로 캐스팅합니다.
             if (UStaticMeshComponent* pMesh = dynamic_cast<UStaticMeshComponent*>(*FoundObj))
             {
                  StaticMeshObjs.Add(pMesh);
             }
        }
    }); 
    
    이 부분에서 Culling을 진행하는 데 여기서 하면 안되는 건가 싶기도 하네요